### PR TITLE
feat(ERROR): propagate the actual axios error information

### DIFF
--- a/src/modules/error/error.request.ts
+++ b/src/modules/error/error.request.ts
@@ -1,0 +1,12 @@
+import type { AxiosError } from "axios";
+
+class RequestError extends Error {
+  statusCode: number | undefined;
+
+  constructor(err: AxiosError) {
+    super(err.message);
+    if (err.response) this.statusCode = err.response.status;
+  }
+}
+
+export default RequestError;

--- a/src/modules/request/request.service.ts
+++ b/src/modules/request/request.service.ts
@@ -46,6 +46,7 @@ import {
   IUserGetWeeklyChartListParams,
   IUserGetWeeklyTrackChartParams,
 } from "../user/params.interface";
+import RequestError from "../error/error.request";
 import axios from "axios";
 
 axios.defaults.baseURL = "https://ws.audioscrobbler.com";
@@ -109,8 +110,8 @@ export class ApiRequest {
       });
 
       return data;
-    } catch (error) {
-      throw new Error(error);
+    } catch (err) {
+      throw new RequestError(err);
     }
   }
 }

--- a/test/modules/error.request.test.ts
+++ b/test/modules/error.request.test.ts
@@ -1,0 +1,49 @@
+import type { AxiosError } from "axios";
+import RequestError from "../../src/modules/error/error.request";
+
+const mockAxiosError: AxiosError = {
+  isAxiosError: true,
+  toJSON: jest.fn(),
+  config: null,
+  name: null,
+  message: "Test Error Message",
+};
+
+const mockAxiosResponse = {
+  data: null,
+  status: 404,
+  statusText: null,
+  headers: {},
+  config: null,
+};
+
+describe("RequestError tests", () => {
+  let error: RequestError;
+  let mockError: typeof mockAxiosError;
+
+  beforeEach(() => {
+    mockError = { ...mockAxiosError };
+  });
+
+  describe("when there is a status code", () => {
+    beforeEach(() => {
+      mockError.response = mockAxiosResponse;
+      error = new RequestError(mockError);
+    });
+
+    it("should report the correct status code", () => {
+      expect(error.statusCode).toBe(mockError.response.status);
+      expect(error.message).toBe(mockError.message);
+    });
+  });
+  describe("when there is NOT a status code", () => {
+    beforeEach(() => {
+      error = new RequestError(mockError);
+    });
+
+    it("should report the correct status code", () => {
+      expect(error.statusCode).toBeUndefined();
+      expect(error.message).toBe(mockError.message);
+    });
+  });
+});


### PR DESCRIPTION
Hi @castilh0s,

I was hoping you might consider this PR.
The original Axios status code is lost, when the error is rethrown like this.

The status code is useful for detecting rate-limiting, or user not found scenarios...
I'd like to propose just throwing the original Axios error instead.

(Alternatively, I would propose a custom error for your library, which would encapsulate the status code from Axios... you may prefer this... I'm happy to modify the PR to suit this as well.)

Thanks again for this library!